### PR TITLE
Make babypython turing complete

### DIFF
--- a/baby-python.cpp
+++ b/baby-python.cpp
@@ -18,7 +18,7 @@
 
 
 const int MAX_REPR = 80;
-const int MAX_RECURSION = 2000;
+const int MAX_RECURSION = 20000;
 
 class Object;
 class ASTNode;

--- a/baby-python.cpp
+++ b/baby-python.cpp
@@ -1446,6 +1446,7 @@ int main(int argc, char** argv) {
   std::cout << "                     num = -123        add(x, x)   get(lst, i)   map(f, lst)" << std::endl;
   std::cout << "               oo    lst = [1, 2, 3]   mul(x, x)   len(lst)      reduce(f, lst)" << std::endl;
   std::cout << ". . . __/\\_/\\_/`'    f = def(x) single-expr   f = def(x, y) { ... ; last-expr }" << std::endl;
+  std::cout << "                     equals(a, b)      if cond expr else expr" << std::endl;
   std::cout << std::endl;
 
   linenoise::LoadHistory(".baby-python-history");

--- a/baby-python.cpp
+++ b/baby-python.cpp
@@ -18,7 +18,7 @@
 
 
 const int MAX_REPR = 80;
-const int MAX_RECURSION = 20;
+const int MAX_RECURSION = 2000;
 
 class Object;
 class ASTNode;


### PR DESCRIPTION
Hi Jim,

we had a discussion at lunch during the python school about babypython being turing complete and it inspired me to try and implement some additional functionality for babypython.

### Changes
I implemented bools (`True` and `False`), an `equals` function and branching with the syntax `if boolean-expression expression else expression`.


```python
>> x = 4
4
>> if equals(x, 1) [1,2,3] else [4,5,6]
[4, 5, 6]
>> x = 1
1
>> if equals(x, 1) [1,2,3] else [4,5,6]
[1, 2, 3]
```
`equals` can compare ints, bools and lists and does so element-wise and recursively for the latter:
```python
>> equals(1, True)
False
>> equals([1, 2, [3, [4]]], [1, 2, [3, 4]])
False
>> equals([1, 2, [3, [4]]], [1, 2, [3, [4]]])
True
```

### A standard library for babypython

These changes allow for a neat little "standard library" for babypython *in* babypython:

Boolean operations can be easily defined:
```python
and = def(a, b) if a if b True else False else False
or = def(a, b) if a True else if b True else False
not = def(a) if a False else True
```
which allows to define handy `any` and `all` functions:
```python
all = def(lst) reduce(and, lst)
any = def(lst) reduce(or, lst)

>> any(map(def(x) equals(x, 0), [1, 1, 5, 0, 2]))
True
```

`range`, `reverse`, `elem` (checking if a value is in a list), `filter` and `zip`:
```python
range = def(start, end) { r_ = def(start, end, acc) if equals(start, end) acc else r_(add(start, 1), end, add(acc, [start])) ; r_(start, end, []) }
reverse = def(lst) { r_ = def(orig, reversed, i) if equals(i, -1) reversed else r_(orig, add(reversed, [get(orig, i)]), add(i, -1)) ; r_(lst, [], add(len(lst), -1)) }
elem = def(a, lst) { e_ = def(a, lst, i) if equals(i, len(lst)) False else if equals(a, get(lst ,i)) True else e_(a, lst, add(i, 1)) ; if equals(len(lst), 0) False else e_(a, lst, 0) }
filter = def(f, lst) reduce(add, map(def(x) if f(x) [x] else [], lst))
zip = def(lst1, lst2) { z_ = def(lst1, lst2, acc, i) if or(equals(len(lst1), i), equals(len(lst2), i)) acc else z_(lst1, lst2, add(acc, [[get(lst1, i), get(lst2, i)]]), add(i, 1)) ; z_(lst1, lst2, [], 0) }

# example
>> filter(def(a) elem(a, range(1, 5)), [4, 5, 2, 1, 20, 6])
[4, 2, 1]
>> zip(range(0, 3), range(1, 5))
[[0, 1], [1, 2], [2, 3]]
```
(i left everything in its unreadable one-line format so that it can be copy and pasted to the babypython repl)

### Turing completeness
So, is babypython turing complete now?

One way to prove that a language or a set of instructions is turing complete is by simulating a known turing machine in it, one of the simplest ones being [brainfuck](https://esolangs.org/wiki/Brainfuck) (BF).

I have felt compelled to write a BF interpreter in an [unholy oneliner](https://github.com/davekch/b) before, so I gave it a shot in babypython.

BF's instructions operate on a memory tape of integers and are as follows:
- `>` : Move the pointer to the right
- `<` : Move the pointer to the left
- `+` : Increment the memory cell at the pointer
- `-` : Decrement the memory cell at the pointer
- `.` : Output the character signified by the cell at the pointer
- `,` : Input a character and store it in the cell at the pointer
- `[` : Jump past the matching ] if the cell at the pointer is 0
- `]` : Jump back to the matching [ if the cell at the pointer is nonzero

Since there are no strings in babypython, let's just enumerate the symbols `> -> 0`, `< -> 1`, `+ -> 2`, ... such that BF code can be represented as a list of integers.
Babypython also lacks print and input functions, so our BF intepreter additionally takes a list of inputs (instead of waiting for input) and returns a list of outputs (instead of printing), giving it a signature like
```
brainfuck_eval(code: [int], inputs: [int]) -> [tape: [int], outputs: [int]]
```

A couple of helper-functions:
```python
# get a slice from a list
slice = def(lst, start, end) { s_ = def(lst, start, end, acc) if equals(start, end) acc else s_(lst, add(start, 1), end, add(acc, [get(lst, start)])) ; s_(lst, start, end, []) }
# get everything but the first element of a list
tail = def(lst) slice(lst, 1, len(lst))
# get a n-long list of xs
repeat = def(x, n) if equals(n, 0) [] else add([x], repeat(x, add(n, -1)))
# set the ith element in lst to x
set_elem = def(lst, i, x) add(slice(lst, 0, i), add([x], slice(lst, add(i, 1), len(lst))))
# add x to the ith element in lst
add_at_index = def(lst, i, x) set_elem(lst, i, add(get(lst, i), x))
```
Two extra helpers to find matching brackets (remove newlines before pasting into babypython repl):
```python
# find matching closing bracket; pass position 1 *after* the opening bracket
past_matching_closing = def(code, pos) {
    find_ = def(code, pos, count)
        if equals(get(code, pos), 7)
            if equals(count, 0) add(pos, 1)
            else find_(code, add(pos, 1), add(count, -1))
        else
            if equals(get(code, pos), 6) find_(code, add(pos, 1), add(count, 1))
            else find_(code, add(pos, 1), count)
    ;
    find_(code, pos, 0)
}

# find matching opening bracket; pass position 1 *before* closing bracket
to_matching_opening = def(code, pos) {
    find_ = def(code, pos, count)
        if equals(get(code, pos), 6)
            if equals(count, 0) pos
            else find_(code, add(pos, -1), add(count, -1))
        else
            if equals(get(code, pos), 7) find_(code, add(pos, -1), add(count, 1))
            else find_(code, add(pos, -1), count)
    ;
    find_(code, pos, 0)
}
```

Finally, a brainfuck interpreter in babypython:
```python
brainfuck_eval = def(code, inputs) {
    bf_ = def(code, tape, inputs, outputs, pos, pointer)
        if equals(pos, len(code)) [tape, outputs]
        else if equals(get(code, pos), 0) bf_(code, tape, inputs, outputs, add(pos, 1), add(pointer, 1))
        else if equals(get(code, pos), 1) bf_(code, tape, inputs, outputs, add(pos, 1), add(pointer, -1))
        else if equals(get(code, pos), 2) bf_(code, add_at_index(tape, pointer, 1), inputs, outputs, add(pos, 1), pointer)
        else if equals(get(code, pos), 3) bf_(code, add_at_index(tape, pointer, -1), inputs, outputs, add(pos, 1), pointer)
        else if equals(get(code, pos), 4) bf_(code, tape, inputs, add(outputs, [get(tape, pointer)]), add(pos, 1), pointer)
        else if equals(get(code, pos), 5) bf_(code, set_elem(tape, pointer, get(inputs, 0)), tail(inputs), outputs, add(pos, 1), pointer)
        else if equals(get(code, pos), 6)
            if equals(get(tape, pointer), 0) bf_(code, tape, inputs, outputs, past_matching_closing(code, add(pos, 1)), pointer)
            else bf_(code, tape, inputs, outputs, add(pos, 1), pointer)
        else if equals(get(code, pos), 7)
            if not(equals(get(tape, pointer), 0))  bf_(code, tape, inputs, outputs, to_matching_opening(code, add(pos, -1)), pointer)
            else bf_(code, tape, inputs, outputs, add(pos, 1), pointer)
        else -1
    ;
    tape = repeat(0, 2000) ;
    bf_(code, tape, inputs, [], 0, 0)
}
```

Hello World in BF looks like this:
```
++++++++++[>+++++++>++++++++++>+++>+<<<<-]>++.>+.+++++++..+++.>++.<<+++++++++++++++.>.+++.------.--------.>+.>.
```
which, represented using our mapping, is
```
code = [2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 6, 0, 2, 2, 2, 2, 2, 2, 2, 0, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 0, 2, 2, 2, 0, 2, 1, 1, 1, 1, 3, 7, 0, 2, 2, 4, 0, 2, 4, 2, 2, 2, 2, 2, 2, 2, 4, 4, 2, 2, 2, 4, 0, 2, 2, 4, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 4, 0, 4, 2, 2, 2, 4, 3, 3, 3, 3, 3, 3, 4, 3, 3, 3, 3, 3, 3, 3, 3, 4, 0, 2, 4, 0, 4]
```

Test it:
```
>> result = brainfuck_eval(code, [])
[[0, 87, 100, 33, 10, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0...
(119.89 seconds)
>> get(result, 1)
[72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 10]
```

The output is indeed ascii encoded "Hello World!"
```python
>>> "".join([chr(i) for i in [72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100, 33, 10]])
'Hello World!\n'
```

This means babypython can interpret BF code which proves that it is turing complete! 🪅

Notice that it took almost 2 minutes to compute this which might just be a record for the most inefficient hello world program. I also had to increase `MAX_RECURSION` to 20000.

----

I had a lot of fun doing this and just wanted to share. Please close without merging if you would like to keep babypython as minimal as possible.

Cheers,
David